### PR TITLE
Fix an API parameter usage in code

### DIFF
--- a/第二版/Cha 16 -爬虫实战三：百度地图API/Cha 16 -爬虫实战三：百度地图API.ipynb
+++ b/第二版/Cha 16 -爬虫实战三：百度地图API/Cha 16 -爬虫实战三：百度地图API.ipynb
@@ -803,7 +803,7 @@
     "    decodejson = getjson(eachprovince)\n",
     "    for eachcity in decodejson['results']:\n",
     "        city = eachcity['name']\n",
-    "        num = eachcity['num']\n",
+    "        num = getjson(city)['total']\n",
     "        print (city, num)\n",
     "        output = '\\t'.join([city, str(num)]) + '\\r\\n'\n",
     "        with open('cities.txt', \"a+\", encoding='utf-8') as f:\n",
@@ -846,7 +846,7 @@
     "six_cities_list = ['北京市','上海市','重庆市','天津市','香港特别行政区','澳门特别行政区',]\n",
     "for eachprovince in decodejson['results']:\n",
     "    city = eachprovince['name']\n",
-    "    num = eachprovince['num']\n",
+    "    num = getjson(city)['total']\n",
     "    if city in six_cities_list:\n",
     "        output = '\\t'.join([city, str(num)]) + '\\r\\n'\n",
     "        with open('cities.txt', \"a+\", encoding='utf-8') as f:\n",
@@ -1308,7 +1308,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.7.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/第二版/Cha 16 -爬虫实战三：百度地图API/Cha 16 -爬虫实战三：百度地图API.ipynb
+++ b/第二版/Cha 16 -爬虫实战三：百度地图API/Cha 16 -爬虫实战三：百度地图API.ipynb
@@ -1308,7 +1308,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.6.5"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
The original API parameter `num` that passes in was not giving the right answer that we expected.
Instead, using the parameter `total` that returned from `getjson(city)` will give the total number of the parks in each city, as the codes supposed to do.